### PR TITLE
Resolved MoveIt config problem

### DIFF
--- a/src/manipulator_moveit_config/config/ros_controllers.yaml
+++ b/src/manipulator_moveit_config/config/ros_controllers.yaml
@@ -18,6 +18,18 @@ hardware_interface:
 joint_state_controller:
   type: joint_state_controller/JointStateController
   publish_rate: 50
+
+arm_controller:
+  type: position_controllers/JointTrajectoryController
+  joints:
+    - base_joint
+    - rev_joint1
+    - rev_joint2
+  gains:
+    base_joint: {p: 10000.0, i: 0.01, d: 1.0}
+    rev_joint1: {p: 10000.0, i: 0.01, d: 1.0}
+    rev_joint2: {p: 10000.0, i: 0.01, d: 1.0}
+
 controller_list:
   - name: arm_controller
     action_ns: follow_joint_trajectory

--- a/src/manipulator_moveit_config/launch/demo_gazebo.launch
+++ b/src/manipulator_moveit_config/launch/demo_gazebo.launch
@@ -25,7 +25,7 @@
   <arg name="gazebo_gui" default="true"/>
   <arg name="paused" default="false"/>
   <!-- By default, use the urdf location provided from the package -->
-  <arg name="urdf_path" default="$(find arm)/urdf/arm.urdf"/>
+  <arg name="urdf_path" default="$(find manipulator_v1)/manipulator_description/arm/urdf/arm.urdf"/>
 
   <!-- launch the gazebo simulator and spawn the robot -->
   <include file="$(find manipulator_moveit_config)/launch/gazebo.launch" >

--- a/src/manipulator_moveit_config/launch/gazebo.launch
+++ b/src/manipulator_moveit_config/launch/gazebo.launch
@@ -2,7 +2,7 @@
 <launch>
   <arg name="paused" default="false"/>
   <arg name="gazebo_gui" default="true"/>
-  <arg name="urdf_path" default="$(find arm)/urdf/arm.urdf"/>
+  <arg name="urdf_path" default="$(find manipulator_v1)/manipulator_description/arm/urdf/arm.urdf"/>
 
   <!-- startup simulated world -->
   <include file="$(find gazebo_ros)/launch/empty_world.launch">
@@ -15,7 +15,7 @@
   <param name="robot_description" textfile="$(arg urdf_path)" />
 
   <!-- push robot_description to factory and spawn robot in gazebo at the origin, change x,y,z arguments to spawn in a different position -->
-  <node name="spawn_gazebo_model" pkg="gazebo_ros" type="spawn_model" args="-urdf -param robot_description -model robot -x 0 -y 0 -z 0"
+  <node name="spawn_gazebo_model" pkg="gazebo_ros" type="spawn_model" args="-urdf -param robot_description -model robot -x 0 -y 0 -z 0.3"
     respawn="false" output="screen" />
 
   <include file="$(find manipulator_moveit_config)/launch/ros_controllers.launch"/>

--- a/src/manipulator_moveit_config/launch/ros_controllers.launch
+++ b/src/manipulator_moveit_config/launch/ros_controllers.launch
@@ -6,6 +6,6 @@
 
   <!-- Load the controllers -->
   <node name="controller_spawner" pkg="controller_manager" type="spawner" respawn="false"
-    output="screen" args=""/>
+    output="screen" args="joint_state_controller arm_controller"/>
 
 </launch>

--- a/src/manipulator_moveit_config/launch/trajectory_execution.launch.xml
+++ b/src/manipulator_moveit_config/launch/trajectory_execution.launch.xml
@@ -18,7 +18,7 @@
   <!-- Load the robot specific controller manager; this sets the moveit_controller_manager ROS parameter -->
   <arg name="moveit_controller_manager" default="arm" />
   <include file="$(find manipulator_moveit_config)/launch/$(arg moveit_controller_manager)_moveit_controller_manager.launch.xml">
-    <arg name="execution_type" value="$(arg execution_type)" />
+    <!-- <arg name="execution_type" value="$(arg execution_type)" /> -->
   </include>
 
 </launch>

--- a/src/manipulator_v1/manipulator_description/arm/urdf/arm.urdf
+++ b/src/manipulator_v1/manipulator_description/arm/urdf/arm.urdf
@@ -263,7 +263,6 @@
   <!-- ros_controll_plugin -->
   <gazebo>
       <plugin name="gazebo_ros_control" filename="libgazebo_ros_control.so">
-          <robotNamespace>/arm</robotNamespace>
       </plugin>
   </gazebo>
   


### PR DESCRIPTION
Added arm_controller separetly in ros_controllers.yaml to send
commands to the robot in gazebo. Changed the path to the arm.urdf
file. Commented off the "execution_type" argument for
arm_moveit_controller_manager.launch.xml as the argument was not
needed.

PS: If you face any errors like "... controller type not found ... ", make sure you have all the controllers installed. Just execute the following:
```
sudo apt install ros-noetic-ros-control ros-noetic-ros-controllers
```

PPS: The next time you wish to upload the complete catkin workspace, make sure you do not keep a track of the `build` and `devel` folders. Add `.gitignore` and make sure only the `src` directory is tracked.

Reference:
[Link 1](https://ros-planning.github.io/moveit_tutorials/doc/gazebo_simulation/gazebo_simulation.html)